### PR TITLE
Add support to pass custom parameters

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -26,11 +26,12 @@ var nodemonLog = function nodemonLog(filename) {
 };
 
 module.exports = function () {
-    function _class() {
+    function _class(nodemonOptions) {
         _classCallCheck(this, _class);
 
         this.isWebpackWatching = false;
         this.isNodemonRunning = false;
+        this.nodemonCustomOptions = nodemonOptions;
     }
 
     _createClass(_class, [{
@@ -64,15 +65,19 @@ module.exports = function () {
 
             var log = nodemonLog(displayname);
 
-            nodemon(nodemonOptions).on('start', log('Started:', 'green')).on('crash', log('Crashed:', 'red')).on('restart', log('Restarting:', 'cyan')).once('quit', function () {
+            var monitor = nodemon(nodemonOptions);
+
+            monitor.on('start', log('Started:', 'green')).on('crash', log('Crashed:', 'red')).on('restart', log('Restarting:', 'cyan')).once('quit', function () {
                 log('Stopped:', 'cyan')();
-                // So process.exit() // See https://github.com/JacksonGariety/gulp-nodemon/issues/77
             });
 
             this.isNodemonRunning = true;
 
+            // See https://github.com/JacksonGariety/gulp-nodemon/issues/77
             process.on('SIGINT', function () {
-                console.log('Got SIGINT');
+                monitor.once('exit', function () {
+                    process.exit();
+                });
             });
         }
     }]);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "homepage": "https://github.com/Izhaki/nodemon-webpack-plugin.git",
   "dependencies": {
     "chalk": "2.0.1",
+    "lodash": "^4.17.4",
     "nodemon": "1.11.0"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 const path = require( 'path' )
 const nodemon = require( 'nodemon' )
 const chalk = require( 'chalk' )
+const _ = require( 'lodash' )
 
 const getOutputFileMeta = ( compilation ) => {
     const outputFilename = compilation.outputOptions.filename
@@ -19,9 +20,10 @@ const nodemonLog = ( filename ) => ( msg, colour ) => () => console.log(
 
 module.exports = class {
 
-    constructor() {
+    constructor( nodemonOptions ) {
         this.isWebpackWatching = false
         this.isNodemonRunning = false
+        this.nodemonCustomOptions = nodemonOptions
     }
 
     apply( compiler ) {
@@ -40,10 +42,10 @@ module.exports = class {
     }
 
     startMonitoring( filename, displayname ) {
-        const nodemonOptions = {
+        const nodemonOptions = _.assign({
             script: filename,
             watch: filename,
-        }
+        }, this.nodemonCustomOptions )
 
         const log = nodemonLog( displayname )
 

--- a/test/server.js
+++ b/test/server.js
@@ -2,6 +2,8 @@ const express = require( 'express' )
 
 const app = express()
 
+console.log( 'Arguments passed:', process.argv )
+
 app.get( '/', ( req, res ) => {
     res.send( 'Hello World' )
 })

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -27,7 +27,9 @@ const config = {
         }],
     },
     plugins: [
-        new NodemonPlugin(),
+        new NodemonPlugin({
+            args: [ '--test', 'true' ],
+        }),
     ],
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2931,7 +2931,7 @@ lodash.upperfirst@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
Currently is not possible to customize nodemon parameters. Now when you call the constructor of the  `NodemonPlugin` class you can add an object with custom parameters that can override the default ones.

So for example if you do this:

```javascript
new NodemonPlugin({
    args: [ '--test', 'true' ],
}),
```
This will pass `--test` and `true` to the `server.js` script