### PR TITLE
support webpack 4, prevent umet peer dependency errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ramda": "0.24.1"
   },
   "peerDependencies": {
-    "webpack": "^2 || ^3"
+    "webpack": "^2 || ^3 || ^4"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",


### PR DESCRIPTION
Prevent 
```
nodemon-webpack-plugin@0.1.6" has incorrect peer dependency "webpack@^2 || ^3".
```

I've been using this plugin with Webpack 4 and its working fine