### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ new NodemonPlugin({
     verbose: true,
 
     // Node arguments.
-    nodeArgs: [ '--debug=9222' ]
+    nodeArgs: [ '--inspect=3000' ]
 
     // If using more than one entry, you can specify
     // which output file will be restarted.


### PR DESCRIPTION
The --debug flag is deprecated in my current version of Node (v8.11.2) which seems to be more commonly used than past versions. Also, changed the port number to 3000 since it's also a more common port for running servers than 9222—hoping to make people more familiar and comfortable with what they see in the docs.