### PR TITLE
fix: exit nodemon when webpack is running

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ module.exports = class {
     const nodemonOptionsDefaults = {
       script: relativeFileName,
       watch: relativeFileName,
+      signal: 'exit',
     };
 
     const nodemonOptions = {


### PR DESCRIPTION
Tells nodemon to shutdown on exit signal. Right now nodemon doesn't notice a rebuild and keep running. This is a problem if files being locked by nodemon, so webpack isn't allowed to override them.